### PR TITLE
Allow symfony/var-dumper 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">= 8.1",
     "spiral/boot": "^3.7",
-    "symfony/var-dumper": "^6.1"
+    "symfony/var-dumper": "^6.1 || ^7.0"
   },
   "require-dev": {
     "vimeo/psalm": "^5.14",
@@ -38,13 +38,6 @@
   },
   "config": {
     "sort-packages": true
-  },
-  "extra": {
-    "spiral": {
-      "bootloaders": [
-        "Spiral\\Debug\\Bootloader\\DumperBootloader"
-      ]
-    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

Allow **symfony/var-dumper** v7.0.

The bootloader has been removed from composer.json for spiral-packages/discoverer, as the bootloader should be added to the **system** section:
https://github.com/spiral/app/blob/installer/installer/Module/Dumper/Generator/Bootloaders.php#L17