### PR TITLE
fix: link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With `spiral/dumper`, developers can easily inspect and analyze variable values 
 The component provides a wrapper over the `symfony/var-dumper` library. This component sends dumps directly to the browser within HTTP workers or to the `STDERR` output in other environments. 
 
 <p align="center">
-	<a href="https://spiral.dev/docs/basics-debug/current/en#spiral-dumper"><b>Documentation</b></a>
+	<a href="https://spiral.dev/docs/basics-debug#spiral-dumper"><b>Documentation</b></a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With `spiral/dumper`, developers can easily inspect and analyze variable values 
 The component provides a wrapper over the `symfony/var-dumper` library. This component sends dumps directly to the browser within HTTP workers or to the `STDERR` output in other environments. 
 
 <p align="center">
-	<a href="https://spiral.dev/docs/basics-debug/3.7/en#spiral-dumper"><b>Documentation</b></a>
+	<a href="https://spiral.dev/docs/basics-debug/current/en#spiral-dumper"><b>Documentation</b></a>
 </p>
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  |❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

The previous link led to a 404 Not Found error.
 The new link always points to the latest version of the documentation, ensuring users have access to up-to-date information.

